### PR TITLE
fix: skip device node creation when chroot is disabled

### DIFF
--- a/data/unbound.sh
+++ b/data/unbound.sh
@@ -391,8 +391,21 @@ remote-control:
 EOT
 fi
 
-mkdir -p /opt/unbound/etc/unbound/dev && \
-cp -a /dev/random /dev/urandom /dev/null /opt/unbound/etc/unbound/dev/
+# Only create device files if chroot is enabled.
+# When chroot is disabled (chroot: ""), Unbound can access /dev/ directly
+# and creating device nodes requires elevated privileges (CAP_MKNOD).
+chroot_enabled=true
+if [ -f /opt/unbound/etc/unbound/unbound.conf ]; then
+    # Check if chroot is explicitly disabled (empty string)
+    if grep -qE '^\s*chroot:\s*""' /opt/unbound/etc/unbound/unbound.conf; then
+        chroot_enabled=false
+    fi
+fi
+
+if [ "$chroot_enabled" = true ]; then
+    mkdir -p /opt/unbound/etc/unbound/dev && \
+    cp -a /dev/random /dev/urandom /dev/null /opt/unbound/etc/unbound/dev/
+fi
 
 mkdir -p -m 700 /opt/unbound/etc/unbound/var && \
 chown _unbound:_unbound /opt/unbound/etc/unbound/var && \


### PR DESCRIPTION
## Summary

When running Unbound with chroot disabled (`chroot: ""`), the container logs errors from `cp -a` attempting to create device nodes in `/opt/unbound/etc/unbound/dev/`. This fails because:

1. Creating device nodes requires `CAP_MKNOD`
2. When chroot is disabled, Unbound accesses `/dev/` directly—these copies are unnecessary

This PR checks the Unbound config for `chroot: ""` and skips device node creation when chroot is disabled.

## Changes

- Add chroot detection before device node creation in `data/unbound.sh`
- Default to `chroot_enabled=true` (fail-safe: creates nodes when uncertain)

## Alternatives Considered

- **Suppressing `cp -a` errors with a warning message**: Decided against. When chroot *is* enabled but `CAP_MKNOD` is missing, the raw error is appropriate feedback for a misconfigured container. Suppressing it would mask user error.

## Test Plan

- [x] Container with default config (chroot enabled) still creates device nodes
- [x] Container with `chroot: ""` skips device node creation without errors
- [x] Verify Unbound starts successfully in both configurations