### PR TITLE
chore: float Debian base, defer OpenSSL 4.x, document tag policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-20260505 AS openssl
+FROM debian:trixie AS openssl
 LABEL maintainer="Shaan Majid"
 
 ENV VERSION_OPENSSL=openssl-3.6.2 \
@@ -55,7 +55,7 @@ RUN set -e -x && \
         /var/tmp/* \
         /var/lib/apt/lists/*
 
-FROM debian:trixie-20260505 AS unbound
+FROM debian:trixie AS unbound
 LABEL maintainer="Shaan Majid"
 
 ENV NAME=unbound \
@@ -109,7 +109,7 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
         /var/lib/apt/lists/*
 
 
-FROM debian:trixie-20260505
+FROM debian:trixie
 LABEL maintainer="Shaan Majid"
 
 ARG UNBOUND_VERSION=1.24.2

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ docker pull ghcr.io/shaanmajid/unbound:latest
 
 Image versions correspond to the bundled [Unbound](https://nlnetlabs.nl/projects/unbound/about/) version. See the [Dockerfile](Dockerfile) for build details and the [releases page](https://github.com/shaanmajid/unbound-docker/releases) for changelogs.
 
-### Weekly Rebuilds
+### Rebuilds and tag policy
 
-The `latest` and version tags (e.g., `1.24.2`) are rebuilt weekly to include Debian base image security patches. Run `docker pull` to get the freshest build.
+A weekly job rebuilds `latest` and the current release from a fresh Debian base, so `latest` carries OS security patches between Unbound releases. Once a newer version ships, an older `X.Y.Z` tag stops being rebuilt and no longer receives those patches. Pull `latest` for the freshest build, or pin a digest (`@sha256:...`) for a reproducible image.
 
 ## What is Unbound?
 

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,15 @@
         "debian"
       ],
       "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "openssl/openssl"
+      ],
+      "allowedVersions": "<4"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
         "dockerfile"
       ],
       "groupName": "docker-base"
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "debian"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Unpins the Debian base to float on `trixie` (the weekly rebuild keeps it fresh) and guards Renovate from re-pinning it. Caps OpenSSL below 4.0 until the new major is validated, and corrects the documented rebuild scope and tag policy. Renovate will auto-close the now-obsolete #27 and #23 after merge.