### PR TITLE
build: upgrade to Unbound 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,9 @@ FROM debian:trixie AS unbound
 LABEL maintainer="Shaan Majid"
 
 ENV NAME=unbound \
-    UNBOUND_VERSION=1.25.0 \
-    UNBOUND_SHA256=062a6eda723fe2f041bee4079b76981569f1d12e066bbd74800242fc1ebddec7 \
-    UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-1.25.0.tar.gz
+    UNBOUND_VERSION=1.25.1 \
+    UNBOUND_SHA256=0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f \
+    UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-1.25.1.tar.gz
 
 WORKDIR /tmp/src
 
@@ -112,7 +112,7 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
 FROM debian:trixie
 LABEL maintainer="Shaan Majid"
 
-ARG UNBOUND_VERSION=1.25.0
+ARG UNBOUND_VERSION=1.25.1
 ENV NAME=unbound
 ENV SUMMARY="Unbound is a validating, recursive, and caching DNS resolver." \
     DESCRIPTION="Unbound is a validating, recursive, and caching DNS resolver."


### PR DESCRIPTION
Bumps Unbound to 1.25.1 (version, SHA256, and download URL). Security release fixing an RCE (CVE-2026-33278) plus ~10 additional CVEs, so this becomes the rolling `latest`/`1.25`/`1` target once built.