### PR TITLE
fix(ci): publish rolling major and minor tags on weekly rebuild

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -48,8 +48,14 @@ jobs:
             echo "::error::Invalid version format: $version (expected X.Y.Z)"
             exit 1
           fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          major="${version%%.*}"
+          major_minor="${version%.*}"
+          {
+            echo "version=$version"
+            echo "major_minor=$major_minor"
+            echo "major=$major"
+            echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -77,8 +83,12 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.version }}
+            ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.major_minor }}
+            ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.major }}
             ${{ env.GHCR_IMAGE }}:latest
             ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.version }}
+            ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.major_minor }}
+            ${{ env.GHCR_IMAGE }}:${{ steps.version.outputs.major }}
           labels: |
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.title=${{ env.DOCKERHUB_IMAGE }}


### PR DESCRIPTION
The weekly rebuild only re-published `latest` and the exact patch tag (e.g. `1.25.1`), so the rolling `major.minor` (`1.25`) and `major` (`1`) tags drifted — they stayed pinned to the last *release* digest while `latest`/`1.25.1` advanced to each freshly-patched rebuild, leaving anyone who pulls `:1.25` or `:1` on an image that stops getting OS patches between releases.

This derives `major` and `major_minor` from the version the workflow already extracts and publishes them (unconditionally — the rebuild always builds the current/highest version) alongside `latest` and the patch tag, on both registries.

Note: this prevents future drift; the already-stale live tags (`1.25`/`1`, and `1.24`) need a separate one-time retag to correct.